### PR TITLE
Use consistent mail subjects so the messages group together in Gmail

### DIFF
--- a/notifier.py
+++ b/notifier.py
@@ -214,7 +214,7 @@ class Notifier:
             if SEND_EMAIL:
                 recipient = ml
                 asfpy.messaging.mail(
-                    sender="GitBox <git@apache.org>",
+                    sender=f"{user} <git@apache.org>",
                     recipient=recipient,
                     subject=real_subject,
                     message=real_text,

--- a/templates/close_issue.txt
+++ b/templates/close_issue.txt
@@ -1,4 +1,4 @@
-subject: [GitHub] [%(repository)s] %(user)s closed issue #%(issue_id)s: %(title)s
+subject: %(title)s [%(repository)s] #%(issue_id)s
 
 %(user)s closed issue #%(issue_id)s: %(title)s
 URL: %(link)s

--- a/templates/close_pr.txt
+++ b/templates/close_pr.txt
@@ -1,4 +1,4 @@
-subject: [GitHub] [%(repository)s] %(user)s closed pull request #%(pr_id)s: %(title)s
+subject: %(title)s [%(repository)s] #%(pr_id)s
 
 %(user)s closed pull request #%(pr_id)s: %(title)s
 URL: %(link)s

--- a/templates/comment_issue.txt
+++ b/templates/comment_issue.txt
@@ -1,4 +1,4 @@
-subject: [GitHub] [%(repository)s] %(user)s commented on issue #%(issue_id)s: %(title)s
+subject: %(title)s [%(repository)s] #%(issue_id)s
 
 %(user)s commented on issue #%(issue_id)s:
 URL: %(link)s

--- a/templates/comment_pr.txt
+++ b/templates/comment_pr.txt
@@ -1,4 +1,4 @@
-subject: [GitHub] [%(repository)s] %(user)s commented on pull request #%(pr_id)s: %(title)s
+subject: %(title)s [%(repository)s] #%(pr_id)s
 
 %(user)s commented on PR #%(pr_id)s:
 URL: %(link)s

--- a/templates/diffcomment.txt
+++ b/templates/diffcomment.txt
@@ -1,4 +1,4 @@
-subject: [GitHub] [%(repository)s] %(user)s commented on a diff in pull request #%(pr_id)s: %(title)s
+subject: %(title)s [%(repository)s] #%(pr_id)s
 
 %(user)s commented on code in PR #%(pr_id)s:
 URL: %(link)s

--- a/templates/merge_pr.txt
+++ b/templates/merge_pr.txt
@@ -1,4 +1,4 @@
-subject: [GitHub] [%(repository)s] %(user)s merged pull request #%(pr_id)s: %(title)s
+subject: %(title)s [%(repository)s] #%(pr_id)s
 
 %(user)s merged PR #%(pr_id)s:
 URL: %(link)s

--- a/templates/new_issue.txt
+++ b/templates/new_issue.txt
@@ -1,4 +1,4 @@
-subject: [GitHub] [%(repository)s] %(user)s opened a new issue, #%(issue_id)s: %(title)s
+subject: %(title)s [%(repository)s] #%(issue_id)s
 
 %(user)s opened a new issue, #%(issue_id)s:
 URL: %(link)s

--- a/templates/new_pr.txt
+++ b/templates/new_pr.txt
@@ -1,4 +1,4 @@
-subject: [GitHub] [%(repository)s] %(user)s opened a new pull request, #%(pr_id)s: %(title)s
+subject: %(title)s [%(repository)s] #%(pr_id)s
 
 %(user)s opened a new pull request, #%(pr_id)s:
 URL: %(link)s


### PR DESCRIPTION
Unfortunately, Gmail uses subject field only for conversation view, so making subject dynamic ungroups the messages, and it clutters the inbox.

At the same time, when people reply to a regular email thread, they do not update subjects often, so keeping the subject static would help the ones who use Gmail, and it should not hurt much.

I guess "commenter name" could be put to the sender field, so the sender could be like `%(user)s <git@apache.org>` instead of `GitBox <git@apache.org>`

See
* https://lists.apache.org/thread/xk18m7sp46z7d86pwtkvn69mnb906hss
* https://issues.apache.org/jira/browse/INFRA-18350