### PR TITLE
refactor(templates):  Refactored the email templates to allow following them in email clients.

### DIFF
--- a/notifier.py
+++ b/notifier.py
@@ -227,7 +227,7 @@ class Notifier:
             if SEND_EMAIL:
                 recipient = ml
                 asfpy.messaging.mail(
-                    sender="GitBox <git@apache.org>",
+                    sender=f"{user} <git@apache.org>",
                     recipient=recipient,
                     subject=real_subject,
                     message=real_text,

--- a/notifier.yaml
+++ b/notifier.yaml
@@ -15,5 +15,5 @@ templates:
   created_pr: templates/comment_pr.txt
   close_issue: templates/close_issue.txt
   close_pr: templates/close_pr.txt
-  diffcomment_collated_pr: templates/diffcomment.txt
+  diffcomment_collated_pr: templates/diffcomment_pr.txt
   merge_pr: templates/merge_pr.txt

--- a/templates/close_issue.txt
+++ b/templates/close_issue.txt
@@ -1,4 +1,4 @@
-subject: [GitHub] [%(repository)s] %(user)s closed issue #%(issue_id)s: %(title)s
+subject: Re: %(title)s (Issue #%(issue_id)s) [GH %(repository)s]
 
 %(user)s closed issue #%(issue_id)s: %(title)s
 URL: %(link)s

--- a/templates/close_pr.txt
+++ b/templates/close_pr.txt
@@ -1,4 +1,4 @@
-subject: [GitHub] [%(repository)s] %(user)s closed pull request #%(pr_id)s: %(title)s
+subject: Re: %(title)s (PR #%(pr_id)s) [GH %(repository)s]
 
 %(user)s closed pull request #%(pr_id)s: %(title)s
 URL: %(link)s

--- a/templates/comment_issue.txt
+++ b/templates/comment_issue.txt
@@ -1,4 +1,4 @@
-subject: [GitHub] [%(repository)s] %(user)s commented on issue #%(issue_id)s: %(title)s
+subject: Re: %(title)s (Issue #%(issue_id)s) [GH %(repository)s]
 
 %(user)s commented on issue #%(issue_id)s:
 URL: %(link)s

--- a/templates/comment_pr.txt
+++ b/templates/comment_pr.txt
@@ -1,4 +1,4 @@
-subject: [GitHub] [%(repository)s] %(user)s commented on pull request #%(pr_id)s: %(title)s
+subject: Re: %(title)s (PR #%(pr_id)s) [GH %(repository)s]
 
 %(user)s commented on PR #%(pr_id)s:
 URL: %(link)s

--- a/templates/diffcomment_pr.txt
+++ b/templates/diffcomment_pr.txt
@@ -1,4 +1,4 @@
-subject: [GitHub] [%(repository)s] %(user)s commented on a diff in pull request #%(pr_id)s: %(title)s
+subject: Re: %(title)s (PR #%(pr_id)s) [GH %(repository)s]
 
 %(user)s commented on code in PR #%(pr_id)s:
 URL: %(link)s

--- a/templates/merge_pr.txt
+++ b/templates/merge_pr.txt
@@ -1,4 +1,4 @@
-subject: [GitHub] [%(repository)s] %(user)s merged pull request #%(pr_id)s: %(title)s
+subject: Re: %(title)s (PR #%(pr_id)s) [GH %(repository)s]
 
 %(user)s merged PR #%(pr_id)s:
 URL: %(link)s

--- a/templates/new_issue.txt
+++ b/templates/new_issue.txt
@@ -1,4 +1,4 @@
-subject: [GitHub] [%(repository)s] %(user)s opened a new issue, #%(issue_id)s: %(title)s
+subject: %(title)s (Issue #%(issue_id)s) [GH %(repository)s]
 
 %(user)s opened a new issue, #%(issue_id)s:
 URL: %(link)s

--- a/templates/new_pr.txt
+++ b/templates/new_pr.txt
@@ -1,4 +1,4 @@
-subject: [GitHub] [%(repository)s] %(user)s opened a new pull request, #%(pr_id)s: %(title)s
+subject: %(title)s (PR #%(pr_id)s) [GH %(repository)s]
 
 %(user)s opened a new pull request, #%(pr_id)s:
 URL: %(link)s


### PR DESCRIPTION
I am currently confronted with multiple problems related to the increased amount of GitHub emails.

1. I use Outlook, because that's what my company uses as email client. Here I usually have the columnar layout where the titles of the emails only get 1/4-1/3 of the client width. Here I usually only see: "[GitHub][Somecoolrepo]Someuser did..." and that's it ... this doesn't let me follow the projects I'm subscribed to without clicking on every single email. It also doesn't let the emails be grouped together.
2. When I'm doing my board meeting checks I need to inspect a large number of mailinglists in lists.apache.org. However due to the way the subjects are generated, they are not grouped together to discussions so I can't see "hot topics" and it's difficult to read what the project is currently working on (I sort of seem to go blind on the ability to scan lists for interesting things).

So this PR cleans up with this by making sure the initial email and the followups get generated in a way that email clients can group them and that scanning the lists becomes possible again.