### PR TITLE
Refactor github-event-notifier

### DIFF
--- a/notifier.py
+++ b/notifier.py
@@ -131,20 +131,25 @@ class Notifier:
             # Check standard git config
             cfg_path = os.path.join(repo_path, "config")
             cfg = git.GitConfigParser(cfg_path)
-            if not "commits" in scheme:
+
+            # If the yaml scheme is missing parts, weave in the defaults from the git config in their place
+            # Commits mailing list
+            if "commits" not in scheme:
                 scheme["commits"] = (
                     cfg.get("hooks.asfgit", "recips")
                     or self.config["default_recipient"]
                 )
+            # Issues and Pull Requests
             if cfg.has_option("apache", "dev"):
                 default_issue = cfg.get("apache", "dev")
-                if not "issues" in scheme:
+                if "issues" not in scheme:
                     scheme["issues"] = default_issue
-                if not "pullrequests" in scheme:
+                if "pullrequests" not in scheme:
                     scheme["pullrequests"] = default_issue
+            # Jira notification options
             if cfg.has_option("apache", "jira"):
                 default_jira = cfg.get("apache", "jira")
-                if not "jira_options" in scheme:
+                if "jira_options" not in scheme:
                     scheme["jira_options"] = default_jira
 
         if scheme:

--- a/notifier.py
+++ b/notifier.py
@@ -168,10 +168,11 @@ class Notifier:
                     "{issue_type}_{event_category}",  # e.g. pullrequests_comment
                     "{issue_type}",  # e.g. pullrequests
                 )
+                # Special rules that are only valid for bots like dependabot
                 rule_order_bots = (
                     "{issue_type}_{event_category}_bot_{userid}",  # e.g. pullrequests_comment_bot_dependabot
                     "{issue_type}_bot_{userid}",  # e.g. pullrequests_bot_dependabot
-                ) + rule_order_humans  # Add human rules at the end
+                )
 
                 rule_dict = {
                     "issue_type": github_issue_type,
@@ -185,11 +186,11 @@ class Notifier:
                         key = rule.format(rule_dict)
                         if key in scheme and scheme[key]:  # If we have this scheme and it is non-empty, return it
                             return scheme[key]
-                else:  # Humans, so without the bot specific rules
-                    for rule in rule_order_humans:
-                        key = rule.format(rule_dict)
-                        if key in scheme and scheme[key]:  # If we have this scheme and it is non-empty, return it
-                            return scheme[key]
+                # Human rules (also applies to bots with no specific rules for them)
+                for rule in rule_order_humans:
+                    key = rule.format(rule_dict)
+                    if key in scheme and scheme[key]:  # If we have this scheme and it is non-empty, return it
+                        return scheme[key]
                 return self.config["default_recipient"]  # No (non-empty) scheme found, return default git recipient
 
             elif itype == "commit" and "commits" in scheme:

--- a/notifier.py
+++ b/notifier.py
@@ -21,6 +21,7 @@ import asfpy.pubsub
 import asfpy.messaging
 import asfpy.syslog
 import yaml
+import yaml.parser
 import os
 import uuid
 import git

--- a/notifier.py
+++ b/notifier.py
@@ -164,14 +164,15 @@ class Notifier:
                     event_category = "status"
 
                 # Order of preference for scheme (most specific -> least specific)
-                rule_order_humans = (
-                    "{issue_type}_{event_category}",  # e.g. pullrequests_comment
-                    "{issue_type}",  # e.g. pullrequests
-                )
                 # Special rules that are only valid for bots like dependabot
                 rule_order_bots = (
                     "{issue_type}_{event_category}_bot_{userid}",  # e.g. pullrequests_comment_bot_dependabot
                     "{issue_type}_bot_{userid}",  # e.g. pullrequests_bot_dependabot
+                )
+                # Humans (and bots with no bot-specific rules)
+                rule_order_humans = (
+                    "{issue_type}_{event_category}",  # e.g. pullrequests_comment
+                    "{issue_type}",  # e.g. pullrequests
                 )
 
                 rule_dict = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 asfpy>=0.46
 PyYAML
 GitPython
+requests>=2.28.2


### PR DESCRIPTION
- Switch to using a pre-determined ordered list of notification schemes, iterating through them (most specific to least specific) till we find a match
- Fix up some Python grammar
- PEP8-lint with black
- Switch to using the newer asfpy pubsub listener (required changing some functions to async)
- Be more specific in requirements.txt (requests lib was implicitly used, make explicit)

No changes to the intended functionalities were made.