### PR TITLE
Add a list of known bot accounts that do not conform to the standard naming policy for bots

### DIFF
--- a/known-robots.txt
+++ b/known-robots.txt
@@ -1,0 +1,2 @@
+# This is a list of GitHub userIDs that are known to be bots
+codecov-commenter


### PR DESCRIPTION
Some bots do not have the [bot] marker on them on GitHub, but will still need to have the bot specific mailing list targets work for them. We work around this by keeping a list of known bot accounts. If the userid is found in this list, we treat it as a bot.