### PR TITLE
INFRA-23525: Only set parent message-id when we know it's the very first event

### DIFF
--- a/notifier.py
+++ b/notifier.py
@@ -281,7 +281,7 @@ class Notifier:
             msg_headers = {}
             msgid = "<%s-%s@gitbox.apache.org>" % (node_id, str(uuid.uuid4()))
             msgid_OP = "<%s@gitbox.apache.org>" % node_id
-            if action == "open":
+            if action == "open" and not payload.get("changes"):  # NB: If payload has a 'changes' element that is not None, it is NOT a new PR!
                 msgid = msgid_OP  # This is the first email, make a deterministic message id
             else:
                 msg_headers = {"In-Reply-To": msgid_OP}  # Thread from the first PR/issue email


### PR DESCRIPTION
Changes to the main ticket should not be treated as the parent event, so we divert any event with a change-set in it, treat them as child events.